### PR TITLE
bumped vault to v1.0.2

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -6,3 +6,7 @@
 # Blacksmith
 
 - Bumped Blacksmith to v0.4.2
+
+# Vault
+
+- Bumped Vault to v1.0.2

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -6,7 +6,7 @@ safe/safe:
   size: 8305617
   object_id: 93d337a1-db73-4b07-6612-7f7549af8154
   sha: 9e2953994c0a59511a99b7d7fbf0ddef2f6aaf14
-vault/vault_0.6.4_linux_amd64.zip:
-  size: 12221196
-  object_id: c84aefe6-ace4-4b75-897a-05af5f197f29
-  sha: a333a73f9ad0fb137908c8be3d745ce295935e1c
+vault/vault_1.0.2_linux_amd64.zip:
+  size: 35862496
+  object_id: 68102f2c-65fd-48df-41e3-d309d853ca39
+  sha: bf1afd9d0d16eb474b9fdb0e1fd7e063ecd92edc

--- a/packages/vault/packaging
+++ b/packages/vault/packaging
@@ -4,12 +4,12 @@ set -eu
 # $BOSH_COMPILE_TARGET - where this package & spec'd source files are available
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 
-# from https://releases.hashicorp.com/vault/0.6.4/vault_0.6.4_linux_amd64.zip
+# from https://releases.hashicorp.com/vault/1.0.2/vault_1.0.2_linux_amd64.zip
 
 mkdir ${BOSH_INSTALL_TARGET}/bin
 
 cd vault
-unzip vault_0.6.4_linux_amd64.zip
+unzip vault_1.0.2_linux_amd64.zip
 cp vault ${BOSH_INSTALL_TARGET}/bin
 
 chmod 0755 ${BOSH_INSTALL_TARGET}/bin/*

--- a/packages/vault/spec
+++ b/packages/vault/spec
@@ -2,4 +2,4 @@
 name: vault
 dependencies: []
 files:
-  - vault/vault_0.6.4_linux_amd64.zip
+  - vault/vault_1.0.2_linux_amd64.zip


### PR DESCRIPTION
with older version of vault, we have seen issues like "too many TCP connections in vault" thus caused blacksmith fail to create new services