### PR TITLE
added template and property for blacksmith ca

### DIFF
--- a/jobs/blacksmith/spec
+++ b/jobs/blacksmith/spec
@@ -24,6 +24,7 @@ templates:
   config/nginx.conf:    config/nginx.conf
   config/tls/nginx.pub: config/tls/nginx.pub
   config/tls/nginx.key: config/tls/nginx.key
+  config/tls/blacksmith_services_ca: config/tls/blacksmith_services_ca
 
 properties:
   debug:
@@ -97,3 +98,6 @@ properties:
   bosh.releases:
     description: "A list of releases to upload.  Each item in the list should have a `name`, `version`, `url` and `sha1` parameter."
     default: []
+
+  blacksmith_services_ca.tls.ca_cert:
+    description: PEM encoded CA certificate provided by blacksmith

--- a/jobs/blacksmith/templates/config/tls/blacksmith_services_ca
+++ b/jobs/blacksmith/templates/config/tls/blacksmith_services_ca
@@ -1,0 +1,1 @@
+<%= p('blacksmith_services_ca.tls.ca_cert') %>


### PR DESCRIPTION
The following changes allow for the creation of `blacksmith_services_ca` CA certificate to be used by blacksmith deployed services:

* Updates `jobs/blacksmith/spec` to 
  * include `blacksmith_services_ca` template
  * `blacksmith_services_ca.tls.ca_cert` property

* Creates `jobs/blacksmith/templates/config/tls/blacksmith_services_ca` template
